### PR TITLE
feat: reduzir verbosidade do log do Inno Setup no CI

### DIFF
--- a/.github/workflows/homologation.yml
+++ b/.github/workflows/homologation.yml
@@ -65,7 +65,7 @@ jobs:
         shell: powershell
         run: |
           # --- Build do instalador ---
-          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" "src\foundation\InnoSetup\duimp.iss"
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /Qp "src\foundation\InnoSetup\duimp.iss"
           # --- Identificar o instalador gerado ---
           $file = Get-ChildItem -Path "installers\duimp-*.exe" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
           if (-not $file) {

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -65,7 +65,7 @@ jobs:
         shell: powershell
         run: |
           # --- Build do instalador ---
-          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" "src\foundation\InnoSetup\duimp.iss"
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /Qp "src\foundation\InnoSetup\duimp.iss"
           # --- Identificar o instalador gerado ---
           $file = Get-ChildItem -Path "installers\duimp-*.exe" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
           if (-not $file) {


### PR DESCRIPTION
- Alterado comando de compilação do instalador para usar `/Qp` (quiet progress), deixando o log do GitHub Actions mais limpo.
- Mantém mensagens de progresso e resultado final da compilação, mas oculta detalhes de parsing de seções do script .iss.