### PR TITLE
Ajuste no processo de versionamento:

### DIFF
--- a/build-main.bat
+++ b/build-main.bat
@@ -5,9 +5,6 @@ echo ====================================
 echo Compiling Delphi 12.3 for environment: main
 echo ====================================
 
-REM ============================
-REM Paths
-REM ============================
 set PROJECT_PATH=C:\actions-runner\_work\duimp\duimp\src\client\Siscomex.groupproj
 set DPROJ_PATH=C:\actions-runner\_work\duimp\duimp\src\client\duimp.dproj
 set VERSION_FILE=C:\actions-runner\_work\duimp\version.txt
@@ -15,6 +12,11 @@ set VERSION_FILE=C:\actions-runner\_work\duimp\version.txt
 REM ============================
 REM Read current version
 REM ============================
+set MAJOR=0
+set MINOR=0
+set RELEASE=0
+set BUILD=0
+
 for /f "tokens=1-4 delims=." %%a in (%VERSION_FILE%) do (
     set MAJOR=%%a
     set MINOR=%%b
@@ -22,27 +24,27 @@ for /f "tokens=1-4 delims=." %%a in (%VERSION_FILE%) do (
     set BUILD=%%d
 )
 
-REM ============================
-REM Increment build
-REM ============================
-set /a BUILD=BUILD+1
+set /a BUILD+=1
 set NEW_VERSION=!MAJOR!.!MINOR!.!RELEASE!.!BUILD!
 
-REM ============================
-REM Update duimp project (.dproj)
-REM ============================
 echo Updating duimp project to version !NEW_VERSION!
 
-powershell -Command "(gc '%DPROJ_PATH%') -replace 'FileVersion=\"\d+\.\d+\.\d+\.\d+\"', 'FileVersion=\"!MAJOR!.!MINOR!.!RELEASE!.!BUILD!\"' | Set-Content '%DPROJ_PATH%'"
-powershell -Command "(gc '%DPROJ_PATH%') -replace 'ProductVersion=\"\d+\.\d+\.\d+\.\d+\"', 'ProductVersion=\"!MAJOR!.!MINOR!.!RELEASE!.!BUILD!\"' | Set-Content '%DPROJ_PATH%'"
+REM ============================
+REM Update duimp project (.dproj) safely
+REM ============================
+powershell -Command ^
+  "$content = Get-Content '%DPROJ_PATH%'; " ^
+  "$content = $content -replace 'FileVersion=\"\d+\.\d+\.\d+\.\d+\"', 'FileVersion=\"!NEW_VERSION!\"'; " ^
+  "$content = $content -replace 'ProductVersion=\"\d+\.\d+\.\d+\.\d+\"', 'ProductVersion=\"!NEW_VERSION!\"'; " ^
+  "Set-Content '%DPROJ_PATH%' $content"
 
 REM ============================
-REM Load Delphi 12.3 environment
+REM Load Delphi environment
 REM ============================
 call "C:\Program Files (x86)\Embarcadero\Studio\23.0\bin\rsvars.bat"
 
 REM ============================
-REM Compile the project
+REM Compile project
 REM ============================
 msbuild.exe "%PROJECT_PATH%" ^
   /t:Build ^

--- a/build-stable.bat
+++ b/build-stable.bat
@@ -5,9 +5,6 @@ echo ====================================
 echo Compiling Delphi 12.3 for environment: stable
 echo ====================================
 
-REM ============================
-REM Paths
-REM ============================
 set PROJECT_PATH=C:\actions-runner\_work\duimp\duimp\src\client\Siscomex.groupproj
 set DPROJ_PATH=C:\actions-runner\_work\duimp\duimp\src\client\duimp.dproj
 set VERSION_FILE=C:\actions-runner\_work\duimp\version.txt
@@ -15,6 +12,11 @@ set VERSION_FILE=C:\actions-runner\_work\duimp\version.txt
 REM ============================
 REM Read current version
 REM ============================
+set MAJOR=0
+set MINOR=0
+set RELEASE=0
+set BUILD=0
+
 for /f "tokens=1-4 delims=." %%a in (%VERSION_FILE%) do (
     set MAJOR=%%a
     set MINOR=%%b
@@ -22,27 +24,27 @@ for /f "tokens=1-4 delims=." %%a in (%VERSION_FILE%) do (
     set BUILD=%%d
 )
 
-REM ============================
-REM Increment build
-REM ============================
-set /a BUILD=BUILD+1
+set /a BUILD+=1
 set NEW_VERSION=!MAJOR!.!MINOR!.!RELEASE!.!BUILD!
 
-REM ============================
-REM Update duimp project (.dproj)
-REM ============================
 echo Updating duimp project to version !NEW_VERSION!
 
-powershell -Command "(gc '%DPROJ_PATH%') -replace 'FileVersion=\"\d+\.\d+\.\d+\.\d+\"', 'FileVersion=\"!MAJOR!.!MINOR!.!RELEASE!.!BUILD!\"' | Set-Content '%DPROJ_PATH%'"
-powershell -Command "(gc '%DPROJ_PATH%') -replace 'ProductVersion=\"\d+\.\d+\.\d+\.\d+\"', 'ProductVersion=\"!MAJOR!.!MINOR!.!RELEASE!.!BUILD!\"' | Set-Content '%DPROJ_PATH%'"
+REM ============================
+REM Update duimp project (.dproj) safely
+REM ============================
+powershell -Command ^
+  "$content = Get-Content '%DPROJ_PATH%'; " ^
+  "$content = $content -replace 'FileVersion=\"\d+\.\d+\.\d+\.\d+\"', 'FileVersion=\"!NEW_VERSION!\"'; " ^
+  "$content = $content -replace 'ProductVersion=\"\d+\.\d+\.\d+\.\d+\"', 'ProductVersion=\"!NEW_VERSION!\"'; " ^
+  "Set-Content '%DPROJ_PATH%' $content"
 
 REM ============================
-REM Load Delphi 12.3 environment
+REM Load Delphi environment
 REM ============================
 call "C:\Program Files (x86)\Embarcadero\Studio\23.0\bin\rsvars.bat"
 
 REM ============================
-REM Compile the project
+REM Compile project
 REM ============================
 msbuild.exe "%PROJECT_PATH%" ^
   /t:Build ^


### PR DESCRIPTION
- build-stable.bat não grava mais no version.txt
- version.txt passa a ser atualizado somente após o deploy em homologação