### PR TITLE
Ajuste na majoração e na lógica de recarregar a duimp

### DIFF
--- a/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.dfm
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.dfm
@@ -2282,9 +2282,7 @@ inherited damDuimp: TdamDuimp
           #9',Majorado = '
           #9' SUM('
           #9#9'CASE'
-          
-            #9#9#9'WHEN DMC.TipoAliquota = '#39'AD_VALOREM'#39' AND DMC.TipoAliquota = '#39 +
-            #39
+          #9#9#9'WHEN DMC.TipoAliquota = '#39'AD_VALOREM'#39' OR DMC.TipoAliquota = '#39#39
           #9#9#9#9'THEN DVB.ARecolher'
           #9#9#9'ELSE DMC.ValorAliquotaEspecifica * DCI.QuantidadeComercial'
           #9#9'END)'
@@ -8549,6 +8547,7 @@ inherited damDuimp: TdamDuimp
       ',CONF.SISCOMEX_Documento'
       ',CONF.SISCOMEX_CentroCusto'
       ',CONF.Ramo_Atividade'
+      ',CONF.Processo_ImportarFechado'
       'FROM Configuracao AS CONF')
     Left = 818
     Top = 271
@@ -8613,6 +8612,10 @@ inherited damDuimp: TdamDuimp
     object qryCONRamo_Atividade: TSmallintField
       FieldName = 'Ramo_Atividade'
       Origin = 'Ramo_Atividade'
+    end
+    object qryCONProcesso_ImportarFechado: TBooleanField
+      FieldName = 'Processo_ImportarFechado'
+      Origin = 'Processo_ImportarFechado'
     end
   end
   object dsoITR: TDataSource

--- a/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.pas
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.pas
@@ -937,6 +937,7 @@ type
     qryITRUnidadeComercialCodigo: TStringField;
     qryDPRUnidadeComercialCodigo: TStringField;
     qryDUVNumero: TStringField;
+    qryCONProcesso_ImportarFechado: TBooleanField;
     procedure DataModuleCreate(Sender: TObject);
     procedure MoedaNegociadaValorGetText(Sender: TField; var Text: string; DisplayText: Boolean);
     procedure qryDUINewRecord(DataSet: TDataSet);
@@ -1037,7 +1038,6 @@ uses
   cbsCore.SysUtils,
   duimp.dom.DataModules.damAttrs,
   duimp.dom.DataModules.damConnection,
-
   duimp.dom.Products.Attributes.FillingForm,
   duimp.dom.System.Application,
   duimp.dom.System.ImportaUtils,

--- a/src/client/duimp.dproj
+++ b/src/client/duimp.dproj
@@ -5,7 +5,7 @@
         <FrameworkType>VCL</FrameworkType>
         <MainSource>duimp.dpr</MainSource>
         <Base>True</Base>
-        <Config Condition="'$(Config)'==''">VCL</Config>
+        <Config Condition="'$(Config)'==''">deVCL</Config>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
         <TargetedPlatforms>3</TargetedPlatforms>
         <AppType>Application</AppType>
@@ -1322,7 +1322,7 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <PreBuildEventIgnoreExitCode>False</PreBuildEventIgnoreExitCode>
         <PreLinkEvent/>
         <PreLinkEventIgnoreExitCode>False</PreLinkEventIgnoreExitCode>
-        <PostBuildEvent>xcopy /Y /S &quot;..\..\certificates\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;&amp;&amp;xcopy /Y /S &quot;..\..\extensions\dlls\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;&amp;&amp;xcopy /Y /S &quot;..\..\extensions\drivers\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;</PostBuildEvent>
+        <PostBuildEvent>xcopy /Y /S &quot;..\..\certificates\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;&amp;&amp;xcopy /Y /S &quot;..\..\extensions\dlls\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;&amp;&amp;xcopy /Y /S &quot;..\..\extensions\drivers\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;</PostBuildEvent>
         <PostBuildEventIgnoreExitCode>False</PostBuildEventIgnoreExitCode>
     </PropertyGroup>
 </Project>

--- a/src/client/pre/view/duimp.pre.view.DuimpPdFFram.dfm
+++ b/src/client/pre/view/duimp.pre.view.DuimpPdFFram.dfm
@@ -1710,10 +1710,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
             object tshGoods: TcxTabSheet
               Caption = 'Mercadorias (0)'
               ImageIndex = 1
-              ExplicitLeft = 0
-              ExplicitTop = 0
-              ExplicitWidth = 0
-              ExplicitHeight = 0
               object lclGoods: TdxLayoutControl
                 Left = 0
                 Top = 0
@@ -1742,10 +1738,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
                   object tshDCI: TcxTabSheet
                     Caption = 'Mercadoria'
                     ImageIndex = 0
-                    ExplicitLeft = 0
-                    ExplicitTop = 0
-                    ExplicitWidth = 0
-                    ExplicitHeight = 0
                     object dxLayoutControl1: TdxLayoutControl
                       Left = 0
                       Top = 0
@@ -2605,10 +2597,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
                   object tshTRI: TcxTabSheet
                     Caption = 'Tributos'
                     ImageIndex = 1
-                    ExplicitLeft = 0
-                    ExplicitTop = 0
-                    ExplicitWidth = 0
-                    ExplicitHeight = 0
                     object dxLayoutControl2: TdxLayoutControl
                       Left = 0
                       Top = 0
@@ -3086,10 +3074,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
                   object tshCamex: TcxTabSheet
                     Caption = 'Camex'
                     ImageIndex = 2
-                    ExplicitLeft = 0
-                    ExplicitTop = 0
-                    ExplicitWidth = 0
-                    ExplicitHeight = 0
                     object lclCamex: TdxLayoutControl
                       Left = 0
                       Top = 0
@@ -3210,10 +3194,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
                   object tshDUM: TcxTabSheet
                     Caption = 'Dumping'
                     ImageIndex = 3
-                    ExplicitLeft = 0
-                    ExplicitTop = 0
-                    ExplicitWidth = 0
-                    ExplicitHeight = 0
                     object lclDUM: TdxLayoutControl
                       Left = 0
                       Top = 0
@@ -3331,10 +3311,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
                   object tshEF: TcxTabSheet
                     Caption = 'Exportador / Fabricante'
                     ImageIndex = 4
-                    ExplicitLeft = 0
-                    ExplicitTop = 0
-                    ExplicitWidth = 0
-                    ExplicitHeight = 0
                     object lclEF: TdxLayoutControl
                       Left = 0
                       Top = 0
@@ -4071,10 +4047,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
             object tshDPG: TcxTabSheet
               Caption = 'Pagamentos (0)'
               ImageIndex = 3
-              ExplicitLeft = 0
-              ExplicitTop = 0
-              ExplicitWidth = 0
-              ExplicitHeight = 0
               object lclDPG: TdxLayoutControl
                 Left = 0
                 Top = 0
@@ -4226,10 +4198,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
             object tshExpFab: TcxTabSheet
               Caption = 'Exportadores / Fabricantes'
               ImageIndex = 4
-              ExplicitLeft = 0
-              ExplicitTop = 0
-              ExplicitWidth = 0
-              ExplicitHeight = 0
               object lclFornFabric: TdxLayoutControl
                 Left = 0
                 Top = 0
@@ -4440,10 +4408,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
             object tshInfCompl: TcxTabSheet
               Caption = 'Informa'#231#227'o Complementar'
               ImageIndex = 2
-              ExplicitLeft = 0
-              ExplicitTop = 0
-              ExplicitWidth = 0
-              ExplicitHeight = 0
               object lclIFC: TdxLayoutControl
                 Left = 0
                 Top = 0

--- a/src/client/pre/view/duimp.pre.view.DuimpPdFFram.pas
+++ b/src/client/pre/view/duimp.pre.view.DuimpPdFFram.pas
@@ -797,7 +797,7 @@ begin
           Application.ProcessMessages;
         end);
       cbxRedoDuimp.Checked := False;
-      cbxRedoDuimp.Enabled := LFounded and (DataModule.qryDUVProcessoNumero.AsString.Trim.IsEmpty and not DataModule.qryProc.IsEmpty) or (not DataModule.qryDUVProcessoNumero.AsString.Trim.IsEmpty and DataModule.qryProc.IsEmpty);
+      cbxRedoDuimp.Enabled := LFounded and DataModule.qryCONProcesso_ImportarFechado.AsBoolean;
       tshDuimp.Caption := Format('Duimp (Versão: %d)', [DataModule.qryDUVVersao.AsInteger]);
       tshGoods.Caption := Format('Mercadorias (%d)', [DataModule.qryDCI.RecordCount]);
       tshDPG.Caption := Format('Pagamentos (%d)', [DataModule.dsoDPGSel.DataSet.RecordCount]);

--- a/src/client/pucomex.dproj
+++ b/src/client/pucomex.dproj
@@ -5,7 +5,7 @@
         <ProjectVersion>20.3</ProjectVersion>
         <FrameworkType>None</FrameworkType>
         <Base>True</Base>
-        <Config Condition="'$(Config)'==''">VCL</Config>
+        <Config Condition="'$(Config)'==''">deVCL</Config>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
         <TargetedPlatforms>1048577</TargetedPlatforms>
         <AppType>Package</AppType>

--- a/src/foundation/cbsCore.dproj
+++ b/src/foundation/cbsCore.dproj
@@ -5,7 +5,7 @@
         <ProjectVersion>20.3</ProjectVersion>
         <FrameworkType>None</FrameworkType>
         <Base>True</Base>
-        <Config Condition="'$(Config)'==''">VCL</Config>
+        <Config Condition="'$(Config)'==''">deVCL</Config>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
         <TargetedPlatforms>1048577</TargetedPlatforms>
         <AppType>Package</AppType>

--- a/src/foundation/cbsMigrations.dproj
+++ b/src/foundation/cbsMigrations.dproj
@@ -5,7 +5,7 @@
         <ProjectVersion>20.3</ProjectVersion>
         <FrameworkType>None</FrameworkType>
         <Base>True</Base>
-        <Config Condition="'$(Config)'==''">VCL</Config>
+        <Config Condition="'$(Config)'==''">deVCL</Config>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
         <TargetedPlatforms>1048577</TargetedPlatforms>
         <AppType>Package</AppType>

--- a/src/foundation/cbsMigrationsFireDac.dproj
+++ b/src/foundation/cbsMigrationsFireDac.dproj
@@ -5,7 +5,7 @@
         <ProjectVersion>20.3</ProjectVersion>
         <FrameworkType>None</FrameworkType>
         <Base>True</Base>
-        <Config Condition="'$(Config)'==''">VCL</Config>
+        <Config Condition="'$(Config)'==''">deVCL</Config>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
         <ProjectName Condition="'$(ProjectName)'==''">cbsMigrationsFireDac</ProjectName>
         <TargetedPlatforms>1048577</TargetedPlatforms>

--- a/src/foundation/updater.dproj
+++ b/src/foundation/updater.dproj
@@ -4,7 +4,7 @@
         <ProjectVersion>20.3</ProjectVersion>
         <FrameworkType>VCL</FrameworkType>
         <Base>True</Base>
-        <Config Condition="'$(Config)'==''">VCL</Config>
+        <Config Condition="'$(Config)'==''">deVCL</Config>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
         <ProjectName Condition="'$(ProjectName)'==''">updater</ProjectName>
         <TargetedPlatforms>3</TargetedPlatforms>


### PR DESCRIPTION
- A não estava lançando a diferença de COFINS devido a lógica que estava sendo aplicado em uma verificação do TipoAliquota;
-  Para que seja possível recarregar a duimp, agora, o sistema se baseia no campo Importar processos com notas fiscais já emitidas;