### PR TITLE
Ajuste na majoração e na lógica de recarregar a duimp

### DIFF
--- a/src/client/duimp.dproj
+++ b/src/client/duimp.dproj
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{527B7D2A-D239-46D8-A6E0-D794F11B9756}</ProjectGuid>
         <ProjectVersion>20.3</ProjectVersion>
@@ -104,7 +104,7 @@
         <DCC_DcpOutput>..\..\build\$(Platform)\$(Config)\.dcp</DCC_DcpOutput>
         <VerInfo_Locale>1046</VerInfo_Locale>
         <DCC_UnitSearchPath>..\..\build;..\..\build\$(Platform)\$(Config);..\..\build\$(Platform)\$(Config)\.dcp;..\..\build\$(Platform)\$(Config)\.bpl;..\..\build\$(Platform)\$(Config)\.dcu;..\modules\WinCryptographyAPIs;..\modules\WinCryptographyAPIs\Authentication;..\modules\WinCryptographyAPIs\Cryptography;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
-        <VerInfo_Keys>CompanyName=Cybersoft Sistemas;FileDescription=Sistema de Integracao Declaracao Unica de Importacao (Duimp);FileVersion=1.0.0.0;InternalName=duimp;LegalCopyright=2025 Cybersoft Sistemas; LegalTrademarks=;OriginalFilename=duimp.exe;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=Cybersoft Duimp;ProductVersion=0.0.0.0;Comments=Aplicacao cliente para integracao com o Siscomex</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=Cybersoft Sistemas;FileDescription=Sistema de Integracao Declaracao Unica de Importacao (Duimp);FileVersion=$(MAJOR).$(MINOR).$(RELEASE).$(BUILD);InternalName=duimp;LegalCopyright=2025 Cybersoft Sistemas; LegalTrademarks=;OriginalFilename=duimp.exe;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=Cybersoft Duimp;ProductVersion=$(MAJOR).$(MINOR).$(RELEASE).$(BUILD);Comments=Aplicacao cliente para integracao com o Siscomex</VerInfo_Keys>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Android)'!=''">
@@ -132,7 +132,7 @@
     <PropertyGroup Condition="'$(Cfg_3_Win32)'!=''">
         <BT_BuildType>Debug</BT_BuildType>
         <Debugger_RunParams>-status updated_system</Debugger_RunParams>
-        <VerInfo_Keys>CompanyName=Cybersoft Sistemas;FileDescription=Sistema de Integracao Declaracao Unica de Importacao (Duimp);FileVersion=1.0.0.0;InternalName=duimp;LegalCopyright=2025 Cybersoft Sistemas; LegalTrademarks=;OriginalFilename=duimp.exe;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=Cybersoft Duimp;ProductVersion=0.0.0.0;Comments=Aplicacao cliente para integracao com o Siscomex</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=Cybersoft Sistemas;FileDescription=Sistema de Integracao Declaracao Unica de Importacao (Duimp);FileVersion=$(MAJOR).$(MINOR).$(RELEASE).$(BUILD);InternalName=duimp;LegalCopyright=2025 Cybersoft Sistemas; LegalTrademarks=;OriginalFilename=duimp.exe;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=Cybersoft Duimp;ProductVersion=$(MAJOR).$(MINOR).$(RELEASE).$(BUILD);Comments=Aplicacao cliente para integracao com o Siscomex</VerInfo_Keys>
         <Icon_MainIcon>duimp_Icon.ico</Icon_MainIcon>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_3_Win64)'!=''">
@@ -1323,7 +1323,10 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <PreBuildEventIgnoreExitCode>False</PreBuildEventIgnoreExitCode>
         <PreLinkEvent/>
         <PreLinkEventIgnoreExitCode>False</PreLinkEventIgnoreExitCode>
-        <PostBuildEvent>xcopy /Y /S &quot;..\..\certificates\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;&amp;&amp;xcopy /Y /S &quot;..\..\extensions\dlls\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;&amp;&amp;xcopy /Y /S &quot;..\..\extensions\drivers\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;</PostBuildEvent>
+        <PostBuildEvent>xcopy /Y /S &quot;..\..\certificates\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;
+&amp;&amp;xcopy /Y /S &quot;..\..\extensions\dlls\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;
+&amp;&amp;xcopy /Y /S &quot;..\..\extensions\drivers\*&quot; &quot;..\..\build\$(Platform)\$(Config)&quot;
+</PostBuildEvent>
         <PostBuildEventIgnoreExitCode>False</PostBuildEventIgnoreExitCode>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
- A não estava lançando a diferença de COFINS devido a lógica que estava sendo aplicado em uma verificação do TipoAliquota;
-  Para que seja possível recarregar a duimp, agora, o sistema se baseia no campo Importar processos com notas fiscais já emitidas;