### PR TITLE
Implementa regra booleana NfOrPi simplificada

### DIFF
--- a/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.dfm
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.dfm
@@ -10491,8 +10491,8 @@ inherited damDuimp: TdamDuimp
       ')'
       'SELECT '
       
-        '    IIF(NOT (C1 = 1 AND C2 = 0), CAST(1 AS bit), CAST(0 AS bit))' +
-        ' AS NfOrPi'
+        '    IIF(C1 = 1 AND C2 = 0, CAST(0 AS bit), CAST(1 AS bit)) AS Nf' +
+        'OrPi'
       'FROM Condicoes;')
     Left = 746
     Top = 590


### PR DESCRIPTION
- Verifica se o processo existe em NotasFiscais ou NotasItens (C1).
- Considera a flag Processo_ImportarFechado em Configuracao (C2).
- Expressão reduzida: NfOrPi retorna 0 apenas quando C1=1 e C2=0, caso contrário retorna 1.