### PR TITLE
Restaurar executável original em falha de atualização

### DIFF
--- a/src/foundation/src/updater.SplashFrm.pas
+++ b/src/foundation/src/updater.SplashFrm.pas
@@ -289,6 +289,7 @@ end;
 
 procedure TfrmSplash.UpdateSystem(var AExecutableName, AParams: string);
 begin
+  var LExecutableName := AExecutableName;
   try
     FUpdateFileName := GetUpdateFileName;
     if not FUpdateFileName.Trim.IsEmpty then
@@ -319,6 +320,7 @@ begin
   except
     on E: Exception do
     begin
+      AExecutableName := LExecutableName;
       Application.NormalizeTopMosts;
       Application.MessageBox(PChar(E.Message), 'Erro', MB_OK or MB_ICONERROR);
       Application.RestoreTopMosts;


### PR DESCRIPTION
- Criada variável local LExecutableName para armazenar o executável atual.
- Em caso de exceção, AExecutableName é restaurado ao valor original.
- Garante que o sistema seja iniciado mesmo se a atualização falhar.