### PR TITLE
fix(logon): salvar filial selecionada no cadastro de empresa

### DIFF
--- a/src/client/pre/view/duimp.pre.view.LogonForm.pas
+++ b/src/client/pre/view/duimp.pre.view.LogonForm.pas
@@ -66,6 +66,7 @@ begin
     begin
       DataModule.mtbLGN.Edit;
       DataModule.mtbLGNCompanyId.AsInteger := DataModule.qryCMPCompanyId.AsInteger;
+      DataModule.mtbLGNCompanyBranch.AsInteger := DataModule.qryCMPBranch.AsInteger;
       DataModule.mtbLGNCompanyName.AsString := DataModule.qryCMPName.AsString;
       DataModule.mtbLGNCompanyState.AsString := DataModule.qryCMPState.AsString;
       DataModule.mtbLGNDatabaseName.AsString := DataModule.qryCMPDatabaseName.AsString;


### PR DESCRIPTION
- Adicionado mapeamento de CompanyBranch no formulário de logon
- Campo mtbLGNCompanyBranch agora recebe valor de qryCMPBranch
- Garante que filial da empresa seja corretamente persistida junto com os demais dados