### PR TITLE
fix: incluir dados do SISCOMEX na consulta de modalidades por versão

### DIFF
--- a/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.dfm
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.dfm
@@ -4352,7 +4352,11 @@ inherited damDuimp: TdamDuimp
       'SET @VersaoId = :Id;'
       ''
       'WITH ModalidadesCTE AS ('
-      #9'SELECT DISTINCT TIP.Codigo, TIP.Descricao'
+      #9'SELECT DISTINCT TIP.Codigo'
+      #9',TIP.Descricao'
+      #9',TIP.SISCOMEX_Orgao'
+      #9',TIP.SISCOMEX_Documento'
+      #9',TIP.SISCOMEX_CentroCusto'
       #9'FROM duimp.capas_itens AS DCI'
       #9'JOIN duimp.modalidades AS MDL'
       #9#9'ON DCI.CaracterizacaoImportacaoIndicador = MDL.Id'
@@ -4368,6 +4372,21 @@ inherited damDuimp: TdamDuimp
       ').value('#39'.'#39', '#39'varchar(max)'#39'), 1, 2, '#39#39')'
       ',Modalidades = STUFF(('
       #9'SELECT '#39'; '#39' + CAST(Descricao AS varchar)'
+      #9'FROM ModalidadesCTE'
+      #9'FOR XML PATH('#39#39'), TYPE'
+      ').value('#39'.'#39', '#39'varchar(max)'#39'), 1, 2, '#39#39')'
+      ',SISCOMEX_Orgao = STUFF(('
+      #9'SELECT '#39'; '#39' + CAST(SISCOMEX_Orgao AS varchar)'
+      #9'FROM ModalidadesCTE'
+      #9'FOR XML PATH('#39#39'), TYPE'
+      ').value('#39'.'#39', '#39'varchar(max)'#39'), 1, 2, '#39#39')'
+      ',SISCOMEX_Documento = STUFF(('
+      #9'SELECT '#39'; '#39' + CAST(SISCOMEX_Documento AS varchar)'
+      #9'FROM ModalidadesCTE'
+      #9'FOR XML PATH('#39#39'), TYPE'
+      ').value('#39'.'#39', '#39'varchar(max)'#39'), 1, 2, '#39#39')'
+      ',SISCOMEX_CentroCusto = STUFF(('
+      #9'SELECT '#39'; '#39' + CAST(SISCOMEX_CentroCusto AS varchar)'
       #9'FROM ModalidadesCTE'
       #9'FOR XML PATH('#39#39'), TYPE'
       ').value('#39'.'#39', '#39'varchar(max)'#39'), 1, 2, '#39#39');')
@@ -4396,6 +4415,27 @@ inherited damDuimp: TdamDuimp
     object qryMDSModalidades: TMemoField
       FieldName = 'Modalidades'
       Origin = 'Modalidades'
+      ReadOnly = True
+      BlobType = ftMemo
+      Size = 2147483647
+    end
+    object qryMDSSISCOMEX_Orgao: TMemoField
+      FieldName = 'SISCOMEX_Orgao'
+      Origin = 'SISCOMEX_Orgao'
+      ReadOnly = True
+      BlobType = ftMemo
+      Size = 2147483647
+    end
+    object qryMDSSISCOMEX_Documento: TMemoField
+      FieldName = 'SISCOMEX_Documento'
+      Origin = 'SISCOMEX_Documento'
+      ReadOnly = True
+      BlobType = ftMemo
+      Size = 2147483647
+    end
+    object qryMDSSISCOMEX_CentroCusto: TMemoField
+      FieldName = 'SISCOMEX_CentroCusto'
+      Origin = 'SISCOMEX_CentroCusto'
       ReadOnly = True
       BlobType = ftMemo
       Size = 2147483647

--- a/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.pas
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.pas
@@ -943,6 +943,9 @@ type
     qryVNF: TFDQuery;
     qryVNFNfOrPi: TBooleanField;
     dsoVNF: TDataSource;
+    qryMDSSISCOMEX_Orgao: TMemoField;
+    qryMDSSISCOMEX_Documento: TMemoField;
+    qryMDSSISCOMEX_CentroCusto: TMemoField;
     procedure DataModuleCreate(Sender: TObject);
     procedure MoedaNegociadaValorGetText(Sender: TField; var Text: string; DisplayText: Boolean);
     procedure qryDUINewRecord(DataSet: TDataSet);
@@ -1119,9 +1122,9 @@ var
 begin 
   cmdPRIns.Unprepare;
   cmdPRIns.Params.ParamByName('CodigoCF').AsString := ASender.FieldByName('CodigoCF').AsString;
-  cmdPRIns.Params.ParamByName('SISCOMEX_Orgao').AsString := qryCON.FieldByName('SISCOMEX_Orgao').AsString;
-  cmdPRIns.Params.ParamByName('SISCOMEX_Documento').AsString := qryCON.FieldByName('SISCOMEX_Documento').AsString;
-  cmdPRIns.Params.ParamByName('SISCOMEX_CentroCusto').AsString := qryCON.FieldByName('SISCOMEX_CentroCusto').AsString;
+  cmdPRIns.Params.ParamByName('SISCOMEX_Orgao').AsString := qryMDS.FieldByName('SISCOMEX_Orgao').AsString;
+  cmdPRIns.Params.ParamByName('SISCOMEX_Documento').AsString := qryMDS.FieldByName('SISCOMEX_Documento').AsString;
+  cmdPRIns.Params.ParamByName('SISCOMEX_CentroCusto').AsString := qryMDS.FieldByName('SISCOMEX_CentroCusto').AsString;
   cmdPRIns.Params.ParamByName('TipoCF').AsString := ASender.FieldByName('TipoCF').AsString;
   cmdPRIns.Params.ParamByName('Data_RegistroDeclaracao').AsDateTime := qryProcData_RegistroDeclaracao.AsDateTime;
   cmdPRIns.Params.ParamByName('Numero_Declaracao').AsString := qryProcNumero_Declaracao.AsString;


### PR DESCRIPTION
- Adicionados campos SISCOMEX_Orgao, SISCOMEX_Documento e SISCOMEX_CentroCusto na CTE ModalidadesCTE
- Incluídas colunas agregadas com STUFF/FOR XML para exibir listas concatenadas desses novos campos
- Agora o resultado traz não só códigos e descrições das modalidades, mas também informações complementares do SISCOMEX