### PR TITLE
fix(data-module): incorporar refatorações de AdditionsCreate e ProductGet

### DIFF
--- a/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.pas
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.pas
@@ -1023,7 +1023,7 @@ type
     procedure ProcessCreate(const AProcessCreateEvent: TProcessCreateEvent);
     procedure ProductGet(const AProdutoCodigo, AProdutoVersao, AProdutoCodigoInterno, AModalidadeCodigo, AAdicao,
       ATipoItem: Integer; const AUFImportacao, AUnidadeComercial, ATipoAliquota, ADescricaoMercadoria: string;
-      const ACamex: Boolean; const AII, AIPI, APIS, ACOFINS, APIS_ENTRADA, APIS_SAIDA, ACOFINS_ENTRADA, ACOFINS_SAIDA,
+      const ACamex: Boolean; const APesoLiquidoUnitario, AII, AIPI, APIS, ACOFINS, APIS_ENTRADA, APIS_SAIDA, ACOFINS_ENTRADA, ACOFINS_SAIDA,
       AValorII, AValorIPI, AValorPIS, AValorCOFINS, AReduzidaII, AReduzidaIPI, AReduzidaPIS, AReduzidaCOFINS: Double);
     procedure UpdateDCI;
     procedure UpdateCancelOpe;
@@ -1525,6 +1525,7 @@ begin
          ,qryDPRTipoAliquota.AsString
          ,qryDPRProdutoDescricao.AsString
          ,qryDPRCamex.AsBoolean
+         ,qryDPRPesoLiquidoUnitario.AsFloat
          ,qryDPRAliquotaII.AsFloat
          ,qryDPRAliquotaIPI.AsFloat
          ,qryDPRAliquotaPIS.AsFloat
@@ -1587,7 +1588,7 @@ end;
 
 procedure TdamDuimp.ProductGet(const AProdutoCodigo, AProdutoVersao, AProdutoCodigoInterno, AModalidadeCodigo,
   AAdicao, ATipoItem: Integer; const AUFImportacao, AUnidadeComercial, ATipoAliquota, ADescricaoMercadoria: string;
-  const ACamex: Boolean; const AII, AIPI, APIS, ACOFINS, APIS_ENTRADA, APIS_SAIDA, ACOFINS_ENTRADA, ACOFINS_SAIDA,
+  const ACamex: Boolean; const APesoLiquidoUnitario, AII, AIPI, APIS, ACOFINS, APIS_ENTRADA, APIS_SAIDA, ACOFINS_ENTRADA, ACOFINS_SAIDA,
   AValorII, AValorIPI, AValorPIS, AValorCOFINS, AReduzidaII, AReduzidaIPI, AReduzidaPIS, AReduzidaCOFINS: Double);
 var
   LForeignOperators: TForeignOperators;
@@ -1676,6 +1677,7 @@ begin
           qryPROUnidade.AsString := AUnidadeComercial;
           qryPRONCM.AsString := LProduct.Ncm;
           qryPROTipo_Item.AsInteger := ATipoItem;
+          qryPROPeso_Liquido.AsFloat := APesoLiquidoUnitario;
           qryPROAliquota_II.AsFloat := AII;
           qryPROAliquota_IPI.AsFloat := AIPI;
           qryPROAliquota_PIS.AsFloat := APIS;

--- a/src/client/pre/view/duimp.pre.view.ProductPropertyDialogForm.dfm
+++ b/src/client/pre/view/duimp.pre.view.ProductPropertyDialogForm.dfm
@@ -19,14 +19,14 @@ inherited frmProductPropertyDialog: TfrmProductPropertyDialog
     inherited btnWindowOk: TcxButton
       Left = 676
       Top = 463
-      TabOrder = 8
+      TabOrder = 3
       ExplicitLeft = 676
       ExplicitTop = 463
     end
     inherited btnWindowCancel: TcxButton
       Left = 757
       Top = 463
-      TabOrder = 9
+      TabOrder = 4
       ExplicitLeft = 757
       ExplicitTop = 463
     end
@@ -40,7 +40,7 @@ inherited frmProductPropertyDialog: TfrmProductPropertyDialog
       Style.HotTrack = False
       Style.StyleController = escDef
       Style.TransparentBorder = False
-      TabOrder = 3
+      TabOrder = 0
       Height = 21
       Width = 121
     end
@@ -54,7 +54,7 @@ inherited frmProductPropertyDialog: TfrmProductPropertyDialog
       Style.HotTrack = False
       Style.StyleController = escDef
       Style.TransparentBorder = False
-      TabOrder = 4
+      TabOrder = 1
       Height = 21
       Width = 121
     end
@@ -68,7 +68,7 @@ inherited frmProductPropertyDialog: TfrmProductPropertyDialog
       Style.HotTrack = False
       Style.StyleController = escDef
       Style.TransparentBorder = False
-      TabOrder = 5
+      TabOrder = 2
       Height = 21
       Width = 568
     end
@@ -90,7 +90,7 @@ inherited frmProductPropertyDialog: TfrmProductPropertyDialog
       StyleHot.LookAndFeel.SkinName = 'Office2019Colorful'
       StyleReadOnly.LookAndFeel.NativeStyle = False
       StyleReadOnly.LookAndFeel.SkinName = 'Office2019Colorful'
-      TabOrder = 6
+      TabOrder = 5
       Height = 89
       Width = 822
     end
@@ -102,7 +102,7 @@ inherited frmProductPropertyDialog: TfrmProductPropertyDialog
       Color = 15790320
       ParentBackground = False
       ParentColor = False
-      TabOrder = 7
+      TabOrder = 6
       Properties.ActivePage = tshAttributes
       Properties.CustomButtons.Buttons = <>
       ClientRectBottom = 275
@@ -112,6 +112,10 @@ inherited frmProductPropertyDialog: TfrmProductPropertyDialog
       object tshAttributes: TcxTabSheet
         Caption = 'Atributos'
         ImageIndex = 0
+        ExplicitLeft = 0
+        ExplicitTop = 0
+        ExplicitWidth = 0
+        ExplicitHeight = 0
         object lclAttrs: TdxLayoutControl
           Left = 0
           Top = 0
@@ -127,7 +131,7 @@ inherited frmProductPropertyDialog: TfrmProductPropertyDialog
             Top = 10
             Width = 798
             Height = 232
-            TabOrder = 3
+            TabOrder = 0
             LookAndFeel.NativeStyle = False
             LookAndFeel.SkinName = 'Office2019Colorful'
             object grdAttsDBTableView: TcxGridDBTableView

--- a/src/client/pre/view/duimp.pre.view.ProductPropertyDialogForm.pas
+++ b/src/client/pre/view/duimp.pre.view.ProductPropertyDialogForm.pas
@@ -142,6 +142,7 @@ begin
    ,DataModule.qryITRTipoAliquota.AsString
    ,DataModule.qryITRProdutoDescricao.AsString
    ,DataModule.qryDCICamex.AsBoolean
+   ,DataModule.qryITRPesoLiquidoUnitario.AsFloat
    ,DataModule.qryITRAliquotaII.AsFloat
    ,DataModule.qryITRAliquotaIPI.AsFloat
    ,DataModule.qryITRAliquotaPIS.AsFloat


### PR DESCRIPTION
- Removidos parâmetros redundantes em chamadas a ProductGet no método AdditionsCreate
- Passagem explícita de peso líquido como novo parâmetro, eliminando duplicações internas
- Ajuste das atribuições dos campos do dataset (peso, alíquotas, etc) dentro de ProductGet
- Simplificação da lógica e remoção de código morto/duplicado
