### PR TITLE
feat(sql): adicionar coluna ICMS_Diferido em incentivos fiscais e filtrar registros ativos

### DIFF
--- a/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.dfm
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.dfm
@@ -7282,6 +7282,7 @@ inherited damDuimp: TdamDuimp
       ',PDO.TUP'
       ',PDO.Banco'
       ',PDO.Incoterms'
+      ',PDO.ICMS_DIferido'
       'FROM ProcessosDocumentos AS PDO'
       'WHERE PDO.Processo = :ProcessoNumero;')
     Left = 496
@@ -7546,14 +7547,20 @@ inherited damDuimp: TdamDuimp
       FixedChar = True
       Size = 3
     end
+    object qryProcICMS_DIferido: TBooleanField
+      FieldName = 'ICMS_DIferido'
+      Origin = 'ICMS_DIferido'
+    end
   end
   object qryIFI: TFDQuery
     IndexFieldNames = 'Nome'
     Connection = damConnection.DBCadastro
     SQL.Strings = (
       'SELECT IFI.Codigo'
-      ',IFI.Nome'
-      'FROM IncentivosFiscais AS IFI')
+      ',IFI.Nome        '
+      ',IFI.ICMS_Diferido'
+      'FROM IncentivosFiscais AS IFI'
+      'WHERE IFI.Desativada = 0')
     Left = 378
     Top = 463
     object qryIFICodigo: TSmallintField
@@ -7565,6 +7572,9 @@ inherited damDuimp: TdamDuimp
       FieldName = 'Nome'
       Origin = 'Nome'
       Size = 15
+    end
+    object qryIFIICMS_Diferido: TBooleanField
+      FieldName = 'ICMS_Diferido'
     end
   end
   object dsoIFI: TDataSource

--- a/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.pas
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.pas
@@ -946,6 +946,8 @@ type
     qryMDSSISCOMEX_Orgao: TMemoField;
     qryMDSSISCOMEX_Documento: TMemoField;
     qryMDSSISCOMEX_CentroCusto: TMemoField;
+    qryIFIICMS_Diferido: TBooleanField;
+    qryProcICMS_DIferido: TBooleanField;
     procedure DataModuleCreate(Sender: TObject);
     procedure MoedaNegociadaValorGetText(Sender: TField; var Text: string; DisplayText: Boolean);
     procedure qryDUINewRecord(DataSet: TDataSet);
@@ -1316,6 +1318,7 @@ begin
   qryProcEntreposto.AsBoolean := qryDUIEntrepostoAduaneiro.AsBoolean;
   qryProcRemover_FreteNacBC.AsBoolean := qryDUIRemoverFreteTerrirtorioNacionalBCImpostos.AsBoolean;
   qryProcIncoterms.AsString := qryDCIIncotermCodigo.AsString;
+  qryProcICMS_DIferido.AsBoolean := qryIFIICMS_Diferido.AsBoolean;
 end;
 
 procedure TdamDuimp.ProcessCancelUpdates;


### PR DESCRIPTION
- Incluída a coluna `ICMS_Diferido` na consulta de `IncentivosFiscais`
- Aplicado filtro `Desativada = 0` para retornar apenas registros ativos
