### PR TITLE
feat(attrs): limpeza e reimportação de atributos de NCM

### DIFF
--- a/src/client/dom/DataModules/duimp.dom.DataModules.damAttrs.dfm
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damAttrs.dfm
@@ -1,5 +1,5 @@
 inherited damAttrs: TdamAttrs
-  Height = 254
+  Height = 328
   Width = 117
   object cmdNCMIns: TFDCommand
     Connection = damConnection.DBCliente
@@ -353,5 +353,21 @@ inherited damAttrs: TdamAttrs
       end>
     Left = 43
     Top = 184
+  end
+  object cmdNATDel: TFDCommand
+    Connection = damConnection.DBCliente
+    CommandKind = skDelete
+    CommandText.Strings = (
+      'DELETE FROM NCMAtributos'
+      'WHERE NCM = :NCM;')
+    ParamData = <
+      item
+        Name = 'NCM'
+        DataType = ftString
+        ParamType = ptInput
+        Value = Null
+      end>
+    Left = 40
+    Top = 256
   end
 end

--- a/src/client/dom/DataModules/duimp.dom.DataModules.damAttrs.pas
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damAttrs.pas
@@ -16,6 +16,7 @@ type
     cmdATSIns: TFDCommand;
     cmdDOMIns: TFDCommand;
     cmdNATIns: TFDCommand;
+    cmdNATDel: TFDCommand;
   public
     procedure Import(const ANcm: string); overload;
     procedure Import(const ANcm, ADescricao, AUnidade, ATipoAliquota: string; const ACamex: Boolean;
@@ -57,6 +58,8 @@ begin
     damConnection.DBCliente.StartTransaction;
   end;
   try
+    cmdNATDel.ParamByName('NCM').AsString := ANcm;
+    cmdNATDel.Execute;
     PComex.Attributes.Ncm.Get(ANcm,
       procedure(const AResponse: INcmAttributesResponse)
       begin


### PR DESCRIPTION
- Adiciona comando DELETE (cmdNATDel) para remover atributos existentes por NCM
- Garante limpeza prévia antes da importação para evitar duplicidade/inconsistência
- Ajusta DataModule para executar exclusão dentro da transação