### PR TITLE
feat(products): adiciona modalidade de operação na consulta e visualização de produtos

### DIFF
--- a/src/client/dom/DataModules/duimp.dom.DataModules.damProducts.dfm
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damProducts.dfm
@@ -7,7 +7,11 @@ inherited damProducts: TdamProducts
       'SELECT ProdId = PRO.Codigo'
       ',PRO.NCM'
       ',Produto   = Red.ReduzidaFinal'
-      ',Descricao = LEFT(Rem.DescricaoFinal, 3700)'
+      ',Descricao = LEFT(Rem.DescricaoFinal, 3700)      '
+      ',Modalidade = '
+      ' CASE WHEN PRO.Origem = '#39'I'#39' THEN '#39'IMPORTACAO'#39
+      '      WHEN PRO.Origem = '#39'N'#39' THEN '#39'EXPORTACAO'#39
+      ' END'
       'FROM Produtos PRO'
       ''
       '-- 1) Normaliza'#231#227'o da descri'#231#227'o reduzida'
@@ -87,6 +91,13 @@ inherited damProducts: TdamProducts
     object qryPRONCM: TStringField
       FieldName = 'NCM'
       Origin = 'NCM'
+      Size = 10
+    end
+    object qryPROModalidade: TStringField
+      DisplayWidth = 11
+      FieldName = 'Modalidade'
+      Origin = 'Modalidade'
+      ReadOnly = True
       Size = 10
     end
     object qryPROProduto: TStringField
@@ -236,10 +247,10 @@ inherited damProducts: TdamProducts
       Size = 7
     end
     object qryEPRmodalidade: TStringField
+      DisplayWidth = 11
       FieldName = 'modalidade'
       Origin = 'modalidade'
       ReadOnly = True
-      Visible = False
       Size = 10
     end
     object qryEPRcpfCnpjRaiz: TStringField

--- a/src/client/dom/DataModules/duimp.dom.DataModules.damProducts.pas
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damProducts.pas
@@ -1,4 +1,4 @@
-unit duimp.dom.DataModules.damProducts;
+﻿unit duimp.dom.DataModules.damProducts;
 
 interface
 
@@ -75,6 +75,7 @@ type
     qryFABcnpj: TStringField;
     updFAB: TFDUpdateSQL;
     qryFABcodigoInterno: TIntegerField;
+    qryPROModalidade: TStringField;
     procedure DataModuleCreate(Sender: TObject);
     procedure qryATTvalorGetText(Sender: TField; var Text: string; DisplayText:
         Boolean);

--- a/src/client/pre/view/duimp.pre.view.DuimpPdFFram.dfm
+++ b/src/client/pre/view/duimp.pre.view.DuimpPdFFram.dfm
@@ -2589,10 +2589,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
                   object tshTRI: TcxTabSheet
                     Caption = 'Tributos'
                     ImageIndex = 1
-                    ExplicitLeft = 0
-                    ExplicitTop = 0
-                    ExplicitWidth = 0
-                    ExplicitHeight = 0
                     object dxLayoutControl2: TdxLayoutControl
                       Left = 0
                       Top = 0
@@ -3057,10 +3053,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
                   object tshCamex: TcxTabSheet
                     Caption = 'Camex'
                     ImageIndex = 2
-                    ExplicitLeft = 0
-                    ExplicitTop = 0
-                    ExplicitWidth = 0
-                    ExplicitHeight = 0
                     object lclCamex: TdxLayoutControl
                       Left = 0
                       Top = 0
@@ -3177,10 +3169,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
                   object tshDUM: TcxTabSheet
                     Caption = 'Dumping'
                     ImageIndex = 3
-                    ExplicitLeft = 0
-                    ExplicitTop = 0
-                    ExplicitWidth = 0
-                    ExplicitHeight = 0
                     object lclDUM: TdxLayoutControl
                       Left = 0
                       Top = 0
@@ -4030,10 +4018,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
             object tshDPG: TcxTabSheet
               Caption = 'Pagamentos (0)'
               ImageIndex = 3
-              ExplicitLeft = 0
-              ExplicitTop = 0
-              ExplicitWidth = 0
-              ExplicitHeight = 0
               object lclDPG: TdxLayoutControl
                 Left = 0
                 Top = 0
@@ -4181,10 +4165,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
             object tshExpFab: TcxTabSheet
               Caption = 'Exportadores / Fabricantes'
               ImageIndex = 4
-              ExplicitLeft = 0
-              ExplicitTop = 0
-              ExplicitWidth = 0
-              ExplicitHeight = 0
               object lclFornFabric: TdxLayoutControl
                 Left = 0
                 Top = 0
@@ -4623,6 +4603,9 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
                     object grdProductsDBTableViewNCM: TcxGridDBColumn
                       DataBinding.FieldName = 'NCM'
                     end
+                    object grdProductsDBTableViewModalidade: TcxGridDBColumn
+                      DataBinding.FieldName = 'Modalidade'
+                    end
                     object grdProductsDBTableViewProduto: TcxGridDBColumn
                       DataBinding.FieldName = 'Produto'
                       Options.GroupFooters = False
@@ -4780,6 +4763,10 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
                     object grdEProductsDBTableViewNCM: TcxGridDBColumn
                       DataBinding.FieldName = 'NCM'
                     end
+                    object grdEProductsDBTableViewModalidade: TcxGridDBColumn
+                      Caption = 'Modalidade'
+                      DataBinding.FieldName = 'Modalidade'
+                    end
                     object grdEProductsDBTableViewdenominacao: TcxGridDBColumn
                       DataBinding.FieldName = 'denominacao'
                     end
@@ -4791,10 +4778,6 @@ inherited fraDuimpPageDef: TfraDuimpPageDef
                     end
                     object grdEProductsDBTableViewSituacao: TcxGridDBColumn
                       DataBinding.FieldName = 'Situacao'
-                      Visible = False
-                    end
-                    object grdEProductsDBTableViewModalidade: TcxGridDBColumn
-                      DataBinding.FieldName = 'Modalidade'
                       Visible = False
                     end
                     object grdEProductsDBTableViewmsg: TcxGridDBColumn

--- a/src/client/pre/view/duimp.pre.view.DuimpPdFFram.pas
+++ b/src/client/pre/view/duimp.pre.view.DuimpPdFFram.pas
@@ -694,6 +694,7 @@ type
     grdEProductsDBTableViewmsg: TcxGridDBColumn;
     grdEProductsDBTableViewcpfCnpjRaiz: TcxGridDBColumn;
     grdEProductsDBTableViewcodigoProduto: TcxGridDBColumn;
+    grdProductsDBTableViewModalidade: TcxGridDBColumn;
     procedure actCancelAttrExecute(Sender: TObject);
     procedure actFindDuimpExecute(Sender: TObject);
     procedure cbxModalidadePropertiesEditValueChanged(Sender: TObject);


### PR DESCRIPTION
- adiciona campo `Modalidade` nas consultas de produtos com suporte a importação e exportação
- exibe modalidade nos grids de produtos e produtos sincronizados
- remove propriedades `Explicit*` redundantes do formulário de DUIMP
- adiciona campo `qryPROModalidade` no DataModule de produtos
- ajusta definição de colunas nos grids da tela de produtos