### PR TITLE
feat(products): adiciona código do fabricante na sincronização de produtos

### DIFF
--- a/src/client/dom/DataModules/duimp.dom.DataModules.damProducts.dfm
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damProducts.dfm
@@ -138,6 +138,7 @@ inherited damProducts: TdamProducts
       ' END'
       ',codigoProduto = PRO.Codigo_DUIMP'
       ',PRO.NaoSincPSiscomex'
+      ',codigoFabricante = PRO.Codigo_Fabricante'
       'FROM Produtos PRO'
       ''
       '-- 1) Normaliza'#231#227'o da descri'#231#227'o reduzida'
@@ -266,6 +267,11 @@ inherited damProducts: TdamProducts
       FieldName = 'codigoProduto'
       Origin = 'codigoProduto'
       Visible = False
+    end
+    object qryEPRcodigoFabricante: TStringField
+      Tag = 1
+      FieldName = 'codigoFabricante'
+      Origin = 'codigoFabricante'
     end
     object qryEPRNaoSincPSiscomex: TBooleanField
       Tag = 1

--- a/src/client/dom/DataModules/duimp.dom.DataModules.damProducts.pas
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damProducts.pas
@@ -76,6 +76,7 @@ type
     updFAB: TFDUpdateSQL;
     qryFABcodigoInterno: TIntegerField;
     qryPROModalidade: TStringField;
+    qryEPRcodigoFabricante: TStringField;
     procedure DataModuleCreate(Sender: TObject);
     procedure qryATTvalorGetText(Sender: TField; var Text: string; DisplayText:
         Boolean);
@@ -495,6 +496,8 @@ begin
         end;
         var LArray := TJSONArray.Create;
         LArray.Add(LProDST.FieldByName('prodId').AsString);
+        if not LProDST.FieldByName('codigoFabricante').AsString.Trim.IsEmpty then
+          LArray.Add(LProDST.FieldByName('codigoFabricante').AsString);
         LJSonObject.AddPair('codigosInterno', LArray);
         var LStream := TStringStream.Create(LJSonObject.ToJSON, TEncoding.UTF8);
         try


### PR DESCRIPTION
- adiciona campo `codigoFabricante` na consulta de produtos exportáveis
- inclui `qryEPRcodigoFabricante` no DataModule de produtos
- envia código do fabricante no array `codigosInterno` durante sincronização com o Portal Siscomex
- mantém envio condicional apenas quando o código do fabricante estiver preenchido