### PR TITLE
fix(products): corrige descrição exportada e normaliza textos com acentuação

### DIFF
--- a/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.pas
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damDuimp.pas
@@ -1,4 +1,4 @@
-unit duimp.dom.DataModules.damDuimp;
+﻿unit duimp.dom.DataModules.damDuimp;
 
 interface
 
@@ -1149,7 +1149,7 @@ begin
   qryProc.Open;
   qryProc.Edit;
   qryProcNumero_Declaracao.AsString := qryDUVNumero.AsString;
-  qryProcTipo.AsString := 'IMPORTAÃÃO';
+  qryProcTipo.AsString := 'IMPORTAÇÃO';
   qryProcUF_Desembaraco.AsString := qryDCRUFDesembaraco.AsString;
   qryProcUF_Importacao.AsString := qryDCRUFImportacao.AsString;
   qryProcProcesso_Mestre.AsString := qryDUIProcessoNumeroVinculado.AsString;
@@ -1807,7 +1807,7 @@ begin
     (qryDTVSelMajorado.AsFloat > 0) and
     not qryCFPis.IsEmpty and (LValue > 0) then
   begin
-    GeneratePaymentAndReceipt(qryCFPis, LValue, 'DiferenÃ§a de PIS importaÃ§Ã£o');
+    GeneratePaymentAndReceipt(qryCFPis, LValue, 'Diferença de PIS importação');
   end;
   // COFINS...
   LValue := qryProcValor_COFINS.AsFloat - qryProcValor_COFINS2.AsFloat;
@@ -1815,7 +1815,7 @@ begin
     (qryDTVSelMajorado.AsFloat > 0) and
     not qryCFCofins.IsEmpty and (LValue > 0) then
   begin
-    GeneratePaymentAndReceipt(qryCFCofins, LValue, 'DiferenÃ§a de COFINS importaÃ§Ã£o');
+    GeneratePaymentAndReceipt(qryCFCofins, LValue, 'Diferença de COFINS importação');
   end;
   // AFRMM...
   LValue := qryProcAFRMM.AsFloat;
@@ -1827,7 +1827,7 @@ begin
   LValue := qryProcTUP.AsFloat;
   if not qryCFTup.IsEmpty and (LValue > 0) then
   begin
-    GeneratePaymentAndReceipt(qryCFTup, LValue, 'Tarifa utilizaÃ§Ã£o PortuÃ¡rio (TUP)');
+    GeneratePaymentAndReceipt(qryCFTup, LValue, 'Tarifa utilização Portuário (TUP)');
   end;
 end;
 
@@ -2006,7 +2006,7 @@ begin
             var LDuimp := AResponse.Content;
             if not SameText(LDuimp.Identificacao.Importador.Ni, PComex.Duimp.NI_IMPORTADOR) then
             begin
-              raise Exception.CreateFmt('A empresa logada ''%s'' nÃ£o Ã© o importador da DUIMP ''%s''.', [
+              raise Exception.CreateFmt('A empresa logada ''%s'' não é o importador da DUIMP ''%s''.', [
                 GetCpfOrCnpfMask(PComex.Duimp.NI_IMPORTADOR), ANumer]);
             end;
             if Assigned(AFindDuimpEvent) then
@@ -2512,11 +2512,11 @@ procedure TdamDuimp.qryDADTipoGetText(Sender: TField; var Text: string; DisplayT
 begin
   if Sender.AsString = 'ACRESCIMO' then
   begin
-    Text := 'ACRÃSCIMO';
+    Text := 'ACRÉSCIMO';
   end
   else if Sender.AsString = 'DEDUCAO' then
   begin
-    Text := 'DEDUÃÃO';
+    Text := 'DEDUÇÃO';
   end;
 end;
 
@@ -2568,7 +2568,7 @@ end;
 
 procedure TdamDuimp.qryDCIFreteSeguroGetText(Sender: TField; var Text: string; DisplayText: Boolean);
 begin
-  Text := if Sender.AsBoolean then 'SIM' else 'NÃO';
+  Text := if Sender.AsBoolean then 'SIM' else 'NÃO';
 end;
 
 procedure TdamDuimp.qryDCINewRecord(DataSet: TDataSet);

--- a/src/client/dom/DataModules/duimp.dom.DataModules.damProducts.dfm
+++ b/src/client/dom/DataModules/duimp.dom.DataModules.damProducts.dfm
@@ -7,7 +7,10 @@ inherited damProducts: TdamProducts
       'SELECT ProdId = PRO.Codigo'
       ',PRO.NCM'
       ',Produto   = Red.ReduzidaFinal'
-      ',Descricao = LEFT(Rem.DescricaoFinal, 3700)      '
+      
+        ',Descricao = LEFT(IIF(CHARINDEX('#39'<{'#39', Rem.DescricaoFinal) > 0, S' +
+        'UBSTRING(Rem.DescricaoFinal, 0, CHARINDEX('#39'<{'#39', Rem.DescricaoFin' +
+        'al) -1), Rem.DescricaoFinal), 3700)      '
       ',Modalidade = '
       ' CASE WHEN PRO.Origem = '#39'I'#39' THEN '#39'IMPORTACAO'#39
       '      WHEN PRO.Origem = '#39'N'#39' THEN '#39'EXPORTACAO'#39
@@ -130,7 +133,10 @@ inherited damProducts: TdamProducts
       'SELECT prodId = PRO.Codigo'
       ',PRO.ncm'
       ',denominacao   = Red.ReduzidaFinal'
-      ',descricao = LEFT(Rem.DescricaoFinal, 3700)'
+      
+        ',descricao = LEFT(IIF(CHARINDEX('#39'<{'#39', Rem.DescricaoFinal) > 0, S' +
+        'UBSTRING(Rem.DescricaoFinal, 0, CHARINDEX('#39'<{'#39', Rem.DescricaoFin' +
+        'al) -1), Rem.DescricaoFinal), 3700)'
       ',situacao = '#39'ATIVADO'#39
       ',Modalidade = '
       ' CASE WHEN PRO.Origem = '#39'I'#39' THEN '#39'IMPORTACAO'#39


### PR DESCRIPTION
- remove conteúdo complementar da descrição do produto a partir do marcador `<{` antes da exportação
- limita descrição saneada a 3700 caracteres nas consultas de produtos e exportação
- corrige textos com caracteres corrompidos por problema de codificação (UTF-8)
- ajusta mensagens, descrições de tributos e rótulos exibidos na interface com acentuação correta
- adiciona BOM UTF-8 nas units ajustadas para preservar caracteres acentuados